### PR TITLE
Prevent versioned databases from exposing their inner workings

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -158,7 +158,7 @@ public class ModelManager implements Model {
 
     @Override
     public ReadOnlyList<Good> getInventory() {
-        return inventory.getCurrentState();
+        return inventory;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -13,6 +13,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
     private Version<AddressBook> version;
 
     public VersionedAddressBook() {
+        super();
         version = new LinearHistory<>(new AddressBook());
     }
 
@@ -20,6 +21,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * Creates a VersionedAddressBook with an initial state containing the {@code Supplier}s in the {@code toBeCopied}.
      */
     public VersionedAddressBook(ReadOnlyList<Supplier> toBeCopied) {
+        super();
         version = new LinearHistory<>(new AddressBook(toBeCopied));
         updateDisplayedSuppliers();
     }

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -12,6 +12,9 @@ import seedu.address.model.version.Versionable;
 public class VersionedAddressBook extends AddressBook implements Versionable {
     private Version<AddressBook> version;
 
+    /**
+     * Creates a VersionedAddressBook with an empty initial state.
+     */
     public VersionedAddressBook() {
         super();
         version = new LinearHistory<>(new AddressBook());

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -30,7 +30,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * Resets the existing data of the current state with {@code newData}.
      */
     public void resetData(ReadOnlyList<Supplier> newData) {
-        getCurrentState().resetData(newData);
+        version.getCurrentState().resetData(newData);
         updateDisplayedSuppliers();
     }
 
@@ -40,7 +40,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * Returns true if a supplier with the same identity as {@code supplier} exists in the current state.
      */
     public boolean hasSupplier(Supplier supplier) {
-        return getCurrentState().hasSupplier(supplier);
+        return version.getCurrentState().hasSupplier(supplier);
     }
 
     /**
@@ -48,7 +48,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * The supplier must not already exist in the current state.
      */
     public void addSupplier(Supplier p) {
-        getCurrentState().addSupplier(p);
+        version.getCurrentState().addSupplier(p);
         updateDisplayedSuppliers();
     }
 
@@ -59,7 +59,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * current state.
      */
     public void setSupplier(Supplier target, Supplier editedSupplier) {
-        getCurrentState().setSupplier(target, editedSupplier);
+        version.getCurrentState().setSupplier(target, editedSupplier);
         updateDisplayedSuppliers();
     }
 
@@ -68,7 +68,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
      * {@code key} must exist in the current state.
      */
     public void removeSupplier(Supplier key) {
-        getCurrentState().removeSupplier(key);
+        version.getCurrentState().removeSupplier(key);
         updateDisplayedSuppliers();
     }
 
@@ -91,16 +91,12 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
         updateDisplayedSuppliers();
     }
 
-    private AddressBook getCurrentState() {
-        return version.getCurrentState();
-    }
-
     //=========== Util Methods =========================================================================
 
     /**
      * Updates the list of suppliers to be shown in the UI.
      */
     private void updateDisplayedSuppliers() {
-        super.resetData(getCurrentState());
+        super.resetData(version.getCurrentState());
     }
 }

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -4,11 +4,12 @@ import seedu.address.model.supplier.Supplier;
 import seedu.address.model.version.LinearHistory;
 import seedu.address.model.version.StateNotFoundException;
 import seedu.address.model.version.Version;
+import seedu.address.model.version.Versionable;
 
 /**
  * An {@code AddressBook} that keeps track of its history. Snapshots of its state are done based on external commands.
  */
-public class VersionedAddressBook extends AddressBook implements Version<AddressBook> {
+public class VersionedAddressBook extends AddressBook implements Versionable {
     private Version<AddressBook> version;
 
     public VersionedAddressBook() {
@@ -90,8 +91,7 @@ public class VersionedAddressBook extends AddressBook implements Version<Address
         updateDisplayedSuppliers();
     }
 
-    @Override
-    public AddressBook getCurrentState() {
+    private AddressBook getCurrentState() {
         return version.getCurrentState();
     }
 

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -18,7 +18,8 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
     }
 
     /**
-     * Creates a VersionedAddressBook with an initial state containing the {@code Supplier}s in the {@code toBeCopied}.
+     * Creates a VersionedAddressBook with an initial state containing the list of {@code Supplier} in the
+     * {@code toBeCopied}.
      */
     public VersionedAddressBook(ReadOnlyList<Supplier> toBeCopied) {
         super();
@@ -28,9 +29,7 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
 
     //=========== List Overwrite Operations =========================================================================
 
-    /**
-     * Resets the existing data of the current state with {@code newData}.
-     */
+    @Override
     public void resetData(ReadOnlyList<Supplier> newData) {
         version.getCurrentState().resetData(newData);
         updateDisplayedSuppliers();
@@ -38,37 +37,25 @@ public class VersionedAddressBook extends AddressBook implements Versionable {
 
     //=========== Supplier-Level Operations =========================================================================
 
-    /**
-     * Returns true if a supplier with the same identity as {@code supplier} exists in the current state.
-     */
+    @Override
     public boolean hasSupplier(Supplier supplier) {
         return version.getCurrentState().hasSupplier(supplier);
     }
 
-    /**
-     * Adds a supplier to the current state.
-     * The supplier must not already exist in the current state.
-     */
+
+    @Override
     public void addSupplier(Supplier p) {
         version.getCurrentState().addSupplier(p);
         updateDisplayedSuppliers();
     }
 
-    /**
-     * Replaces the given supplier {@code target} in the current state with {@code editedSupplier}.
-     * {@code target} must exist in the current state.
-     * The supplier identity of {@code editedSupplier} must not be the same as another existing supplier in the
-     * current state.
-     */
+    @Override
     public void setSupplier(Supplier target, Supplier editedSupplier) {
         version.getCurrentState().setSupplier(target, editedSupplier);
         updateDisplayedSuppliers();
     }
 
-    /**
-     * Removes {@code key} from the current state.
-     * {@code key} must exist in the current state.
-     */
+    @Override
     public void removeSupplier(Supplier key) {
         version.getCurrentState().removeSupplier(key);
         updateDisplayedSuppliers();

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -11,14 +11,14 @@ import seedu.address.model.version.Versionable;
  */
 public class VersionedInventory extends Inventory implements Versionable {
     private Version<Inventory> version;
-
+    
     public VersionedInventory() {
         super();
         version = new LinearHistory<>(new Inventory());
     }
 
     /**
-     * Creates a VersionedInventory with an initial state containing the {@code Good}s in the {@code toBeCopied}.
+     * Creates a VersionedInventory with an initial state containing the list of {@code Good} in the {@code toBeCopied}.
      */
     public VersionedInventory(ReadOnlyList<Good> toBeCopied) {
         super();
@@ -28,9 +28,7 @@ public class VersionedInventory extends Inventory implements Versionable {
 
     //=========== List Overwrite Operations =========================================================================
 
-    /**
-     * Resets the existing data in the current state with {@code newData}.
-     */
+    @Override
     public void resetData(ReadOnlyList<Good> newData) {
         version.getCurrentState().resetData(newData);
         updateDisplayedGoods();
@@ -38,40 +36,30 @@ public class VersionedInventory extends Inventory implements Versionable {
 
     //=========== Good-Level Operations =========================================================================
 
-    /**
-     * Returns true if a good with the same identity as {@code good} exists in the address book.
-     */
+    @Override
     public boolean hasGood(Good good) {
         return version.getCurrentState().hasGood(good);
     }
 
+
+    @Override
     public int index(Good toFind) {
         return version.getCurrentState().index(toFind);
     }
 
-    /**
-     * Adds a good to the current state.
-     * The good must not already exist in the current state.
-     */
+    @Override
     public void addGood(Good p) {
         version.getCurrentState().addGood(p);
         updateDisplayedGoods();
     }
 
-    /**
-     * Replaces the given good {@code target} in the current state with {@code editedGood}.
-     * {@code target} must exist in the current state.
-     * The good identity of {@code editedGood} must not be the same as another existing good in the current state.
-     */
+    @Override
     public void setGood(Good target, Good editedGood) {
         version.getCurrentState().setGood(target, editedGood);
         updateDisplayedGoods();
     }
 
-    /**
-     * Removes {@code key} from this {@code Inventory}.
-     * {@code key} must exist in the current state.
-     */
+    @Override
     public void removeGood(Good key) {
         version.getCurrentState().removeGood(key);
         updateDisplayedGoods();

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -12,6 +12,9 @@ import seedu.address.model.version.Versionable;
 public class VersionedInventory extends Inventory implements Versionable {
     private Version<Inventory> version;
 
+    /**
+     * Creates a VersionedInventory with an empty initial state.
+     */
     public VersionedInventory() {
         super();
         version = new LinearHistory<>(new Inventory());

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -11,7 +11,7 @@ import seedu.address.model.version.Versionable;
  */
 public class VersionedInventory extends Inventory implements Versionable {
     private Version<Inventory> version;
-    
+
     public VersionedInventory() {
         super();
         version = new LinearHistory<>(new Inventory());

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -4,11 +4,12 @@ import seedu.address.model.good.Good;
 import seedu.address.model.version.LinearHistory;
 import seedu.address.model.version.StateNotFoundException;
 import seedu.address.model.version.Version;
+import seedu.address.model.version.Versionable;
 
 /**
  * An {@code Inventory} that keeps track of its history. Snapshots of its state are done based on external commands.
  */
-public class VersionedInventory extends Inventory implements Version<Inventory> {
+public class VersionedInventory extends Inventory implements Versionable {
     private Version<Inventory> version;
 
     public VersionedInventory() {
@@ -93,8 +94,7 @@ public class VersionedInventory extends Inventory implements Version<Inventory> 
         updateDisplayedGoods();
     }
 
-    @Override
-    public Inventory getCurrentState() {
+    private Inventory getCurrentState() {
         return version.getCurrentState();
     }
 

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -13,6 +13,7 @@ public class VersionedInventory extends Inventory implements Versionable {
     private Version<Inventory> version;
 
     public VersionedInventory() {
+        super();
         version = new LinearHistory<>(new Inventory());
     }
 
@@ -20,6 +21,7 @@ public class VersionedInventory extends Inventory implements Versionable {
      * Creates a VersionedInventory with an initial state containing the {@code Good}s in the {@code toBeCopied}.
      */
     public VersionedInventory(ReadOnlyList<Good> toBeCopied) {
+        super();
         version = new LinearHistory<>(new Inventory(toBeCopied));
         updateDisplayedGoods();
     }

--- a/src/main/java/seedu/address/model/VersionedInventory.java
+++ b/src/main/java/seedu/address/model/VersionedInventory.java
@@ -30,7 +30,7 @@ public class VersionedInventory extends Inventory implements Versionable {
      * Resets the existing data in the current state with {@code newData}.
      */
     public void resetData(ReadOnlyList<Good> newData) {
-        getCurrentState().resetData(newData);
+        version.getCurrentState().resetData(newData);
         updateDisplayedGoods();
     }
 
@@ -40,11 +40,11 @@ public class VersionedInventory extends Inventory implements Versionable {
      * Returns true if a good with the same identity as {@code good} exists in the address book.
      */
     public boolean hasGood(Good good) {
-        return getCurrentState().hasGood(good);
+        return version.getCurrentState().hasGood(good);
     }
 
     public int index(Good toFind) {
-        return getCurrentState().index(toFind);
+        return version.getCurrentState().index(toFind);
     }
 
     /**
@@ -52,7 +52,7 @@ public class VersionedInventory extends Inventory implements Versionable {
      * The good must not already exist in the current state.
      */
     public void addGood(Good p) {
-        getCurrentState().addGood(p);
+        version.getCurrentState().addGood(p);
         updateDisplayedGoods();
     }
 
@@ -62,7 +62,7 @@ public class VersionedInventory extends Inventory implements Versionable {
      * The good identity of {@code editedGood} must not be the same as another existing good in the current state.
      */
     public void setGood(Good target, Good editedGood) {
-        getCurrentState().setGood(target, editedGood);
+        version.getCurrentState().setGood(target, editedGood);
         updateDisplayedGoods();
     }
 
@@ -71,7 +71,7 @@ public class VersionedInventory extends Inventory implements Versionable {
      * {@code key} must exist in the current state.
      */
     public void removeGood(Good key) {
-        getCurrentState().removeGood(key);
+        version.getCurrentState().removeGood(key);
         updateDisplayedGoods();
     }
 
@@ -94,16 +94,12 @@ public class VersionedInventory extends Inventory implements Versionable {
         updateDisplayedGoods();
     }
 
-    private Inventory getCurrentState() {
-        return version.getCurrentState();
-    }
-
     //=========== Util Methods =========================================================================
 
     /**
      * Updates the list of suppliers to be shown in the UI.
      */
     private void updateDisplayedGoods() {
-        super.resetData(getCurrentState());
+        super.resetData(version.getCurrentState());
     }
 }

--- a/src/main/java/seedu/address/model/VersionedTransactionHistory.java
+++ b/src/main/java/seedu/address/model/VersionedTransactionHistory.java
@@ -14,6 +14,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
     private Version<TransactionHistory> version;
 
     public VersionedTransactionHistory() {
+        super();
         version = new LinearHistory<>(new TransactionHistory());
     }
 
@@ -22,6 +23,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
      * in the {@code toBeCopied}.
      */
     public VersionedTransactionHistory(ReadOnlyList<Transaction> toBeCopied) {
+        super();
         version = new LinearHistory<>(new TransactionHistory(toBeCopied));
         updateDisplayedTransactions();
     }

--- a/src/main/java/seedu/address/model/VersionedTransactionHistory.java
+++ b/src/main/java/seedu/address/model/VersionedTransactionHistory.java
@@ -13,6 +13,9 @@ import seedu.address.model.version.Versionable;
 public class VersionedTransactionHistory extends TransactionHistory implements Versionable {
     private Version<TransactionHistory> version;
 
+    /**
+     * Creates a VersionedTransactionHistory with an empty initial state.
+     */
     public VersionedTransactionHistory() {
         super();
         version = new LinearHistory<>(new TransactionHistory());

--- a/src/main/java/seedu/address/model/VersionedTransactionHistory.java
+++ b/src/main/java/seedu/address/model/VersionedTransactionHistory.java
@@ -19,7 +19,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
     }
 
     /**
-     * Creates a VersionedTransactionHistory with an initial state containing the {@code Transaction}s
+     * Creates a VersionedTransactionHistory with an initial state containing the list of {@code Transaction}
      * in the {@code toBeCopied}.
      */
     public VersionedTransactionHistory(ReadOnlyList<Transaction> toBeCopied) {
@@ -30,10 +30,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
 
     //=========== List Overwrite Operations =========================================================================
 
-    /**
-     * Resets the existing data of this {@code VersionedTransactionHistory} with {@code newData}.
-     * Resets the history to an empty state as well.
-     */
+    @Override
     public void resetData(ReadOnlyList<Transaction> newData) {
         version.getCurrentState().resetData(newData);
         updateDisplayedTransactions();
@@ -41,26 +38,18 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
 
     //=========== Transaction-Level Operations =========================================================================
 
-    /**
-     * Returns true if a transaction with the same identity as {@code transaction} exists in the current state.
-     */
+    @Override
     public boolean hasTransaction(Transaction transaction) {
         return version.getCurrentState().hasTransaction(transaction);
     }
 
-    /**
-     * Adds a transaction to the current state.
-     * The transaction must not already exist in the current state.
-     */
+    @Override
     public void addTransaction(Transaction p) {
         version.getCurrentState().addTransaction(p);
         updateDisplayedTransactions();
     }
 
-    /**
-     * Removes {@code key} from the current state.
-     * {@code key} must exist in the current state.
-     */
+    @Override
     public void removeTransaction(Transaction key) {
         version.getCurrentState().removeTransaction(key);
         updateDisplayedTransactions();

--- a/src/main/java/seedu/address/model/VersionedTransactionHistory.java
+++ b/src/main/java/seedu/address/model/VersionedTransactionHistory.java
@@ -33,7 +33,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
      * Resets the history to an empty state as well.
      */
     public void resetData(ReadOnlyList<Transaction> newData) {
-        getCurrentState().resetData(newData);
+        version.getCurrentState().resetData(newData);
         updateDisplayedTransactions();
     }
 
@@ -43,7 +43,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
      * Returns true if a transaction with the same identity as {@code transaction} exists in the current state.
      */
     public boolean hasTransaction(Transaction transaction) {
-        return getCurrentState().hasTransaction(transaction);
+        return version.getCurrentState().hasTransaction(transaction);
     }
 
     /**
@@ -51,7 +51,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
      * The transaction must not already exist in the current state.
      */
     public void addTransaction(Transaction p) {
-        getCurrentState().addTransaction(p);
+        version.getCurrentState().addTransaction(p);
         updateDisplayedTransactions();
     }
 
@@ -60,7 +60,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
      * {@code key} must exist in the current state.
      */
     public void removeTransaction(Transaction key) {
-        getCurrentState().removeTransaction(key);
+        version.getCurrentState().removeTransaction(key);
         updateDisplayedTransactions();
     }
 
@@ -83,16 +83,12 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
         updateDisplayedTransactions();
     }
 
-    private TransactionHistory getCurrentState() {
-        return version.getCurrentState();
-    }
-
     //=========== Util Methods =========================================================================
 
     /**
      * Updates the list of suppliers to be shown in the UI.
      */
     private void updateDisplayedTransactions() {
-        super.resetData(getCurrentState());
+        super.resetData(version.getCurrentState());
     }
 }

--- a/src/main/java/seedu/address/model/VersionedTransactionHistory.java
+++ b/src/main/java/seedu/address/model/VersionedTransactionHistory.java
@@ -4,12 +4,13 @@ import seedu.address.model.transaction.Transaction;
 import seedu.address.model.version.LinearHistory;
 import seedu.address.model.version.StateNotFoundException;
 import seedu.address.model.version.Version;
+import seedu.address.model.version.Versionable;
 
 /**
  * A {@code TransactionHistory} that keeps track of its history. Snapshots of its state are done based on external
  * commands.
  */
-public class VersionedTransactionHistory extends TransactionHistory implements Version<TransactionHistory> {
+public class VersionedTransactionHistory extends TransactionHistory implements Versionable {
     private Version<TransactionHistory> version;
 
     public VersionedTransactionHistory() {
@@ -82,8 +83,7 @@ public class VersionedTransactionHistory extends TransactionHistory implements V
         updateDisplayedTransactions();
     }
 
-    @Override
-    public TransactionHistory getCurrentState() {
+    private TransactionHistory getCurrentState() {
         return version.getCurrentState();
     }
 


### PR DESCRIPTION
I noticed that the public `getCurrentState()` allows outside classes to access the database and modify it without going through the versioned databases' API. Thus, I moved it inline. If it was changed to private, it might cause confusion with the method in `Version`.

The superclass constructor is now called explicitly to highlight the dependency. Otherwise, it may be a source of future bugs when someone modifies the superclass constructor without knowing this.